### PR TITLE
Insertar licencia con request

### DIFF
--- a/src/main/resources/db/migration/V1_6__license_request_unique.sql
+++ b/src/main/resources/db/migration/V1_6__license_request_unique.sql
@@ -1,0 +1,3 @@
+DELETE FROM License;
+CREATE UNIQUE INDEX License_id_request_IDX ON License (id_request);
+UPDATE Request set state="IN_REVIEW" where state="APROVED";


### PR DESCRIPTION
- Se trunca la tabla licencia
- Se actualiza el estado de todas las solicitudes aprobadas a IN_REVIEW
- LicenceDAO ahora usa try with resources
- Ya no se están dejando las conexiones abiertas
- ID request es único por licencia